### PR TITLE
XP tracker plugin - Allow hopping/logging out/other GameState changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -56,6 +56,7 @@ public class XpTrackerPlugin extends Plugin
 	private NavigationButton navButton;
 	private XpPanel xpPanel;
 	private final SkillXPInfo[] xpInfos = new SkillXPInfo[NUMBER_OF_SKILLS];
+	private String username = "";
 
 	@Override
 	protected void startUp() throws Exception
@@ -69,10 +70,14 @@ public class XpTrackerPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
-		//reset upon login
+		//reset upon login if character changed
 		if (event.getGameState() == GameState.LOGGED_IN)
 		{
-			xpPanel.resetAllSkillXpHr();
+			if (!username.equals(client.getUsername()))
+			{
+				xpPanel.resetAllSkillXpHr();
+				username = client.getUsername();
+			}
 		}
 	}
 


### PR DESCRIPTION
Allow hopping/logging out/other GameState changes without resetting XP tracker. Tracker automatically resets when changing characters.